### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue';
+
+declare class Multiselect extends Vue { }
+declare class multiselectMixin extends Vue { }
+declare class pointerMixin extends Vue { }
+
+export default Multiselect;
+export { Multiselect, multiselectMixin, pointerMixin };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/vue-multiselect",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/vue-multiselect",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "private": false,
   "scripts": {
     "test": "vue-cli-service test",


### PR DESCRIPTION
Multiselect didn't work with Typescript, because it was missing the type definitions.

I've added it manually, for now, because I don't know if updating the version of Multiselect would break the custom styling added by The Ultimate Avengers.