### PR TITLE
Add type definitions (attempt 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/vue-multiselect",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studyportals/vue-multiselect",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": false,
   "scripts": {
     "test": "vue-cli-service test",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "dependencies": {}
 }


### PR DESCRIPTION
In my first attempt, `index.d.ts` was missing in the package. 
This is now fixed.